### PR TITLE
EP-2943

### DIFF
--- a/eperusteet-opintopolku-app/v2/src/components/EpAmmatillinen/EpPerusteRakenne.vue
+++ b/eperusteet-opintopolku-app/v2/src/components/EpAmmatillinen/EpPerusteRakenne.vue
@@ -66,7 +66,7 @@ export default class EpPerusteRakenne extends Vue {
       .filter(osa => {
         let nimi = osa.nimi;
         if (osa.tutkinnonosa) {
-          nimi = osa.tutkinnonosa.tutkinnonOsa.nimi;
+          nimi = osa.tutkinnonosa.tutkinnonOsa?.nimi || osa.tutkinnonosa.nimi;
         }
         return _.size(osa.osat) > 0 || (nimi && Kielet.search(this.query, nimi));
       })

--- a/eperusteet-opintopolku-app/v2/src/components/EpAmmatillinen/PerusteRakenneOsa.vue
+++ b/eperusteet-opintopolku-app/v2/src/components/EpAmmatillinen/PerusteRakenneOsa.vue
@@ -116,7 +116,7 @@ export default class PerusteRakenneOsa extends Vue {
 
   get nimi() {
     if (this.rakenneosa.tutkinnonosa) {
-      return this.rakenneosa.tutkinnonosa.tutkinnonOsa.nimi;
+      return this.rakenneosa.tutkinnonosa.tutkinnonOsa?.nimi || this.rakenneosa.tutkinnonosa.nimi;
     }
     return this.rakenneosa.nimi;
   }


### PR DESCRIPTION
fallback tutkinnon osan nimen haulle, epPerusteRakennetta käytetään suorituspoluista ja tutkinnonOsista. Näistä komponenteista tulee hieman eri muodossa olevaa dataa. Juuriongelman korjaus olisi laittaa tuleva data samanmuotoiseksi.